### PR TITLE
feat: Lazy load fonts

### DIFF
--- a/wrestling_scoreboard_client/lib/l10n/app_de.arb
+++ b/wrestling_scoreboard_client/lib/l10n/app_de.arb
@@ -15,6 +15,7 @@
   "themeModeLight": "Heller Modus",
   "themeModeDark": "Dunkler Modus",
   "fontFamily": "Schriftart",
+  "systemFont": "System-Schrift",
   "apiUrl": "Api-Url",
   "wsUrl": "Websocket-Url",
   "services": "Dienste",

--- a/wrestling_scoreboard_client/lib/l10n/app_en.arb
+++ b/wrestling_scoreboard_client/lib/l10n/app_en.arb
@@ -18,6 +18,7 @@
   "themeModeLight": "Light mode",
   "themeModeDark": "Dark mode",
   "fontFamily": "Font family",
+  "systemFont": "System font",
   "apiUrl": "Api-Url",
   "wsUrl": "Websocket-Url",
   "services": "Services",

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -151,29 +151,8 @@ class CustomSettingsScreen extends ConsumerWidget {
                             final List<MapEntry<String?, String>> fontFamilies =
                                 GoogleFonts.asMap().keys.map((String e) => MapEntry<String?, String>(e, e)).toList();
                             fontFamilies.insert(0, MapEntry<String?, String>(null, localizations.systemSetting));
-                            return RadioDialog<String?>(
-                                itemCount: fontFamilies.length,
-                                builder: (index) {
-                                  final fontFamily = fontFamilies[index];
-                                  return (
-                                    fontFamily.key,
-                                    Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-                                      Text(fontFamily.value),
-                                      IconButton(
-                                        onPressed: () => showOkDialog(
-                                          context: context,
-                                          child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
-                                              style: fontFamily.key != null
-                                                  ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme)
-                                                      .headlineMedium
-                                                  : null),
-                                        ),
-                                        icon: const Icon(Icons.visibility),
-                                      ),
-                                    ])
-                                  );
-                                },
-                                initialValue: fontFamily);
+                            return FontDialog(
+                                fontFamilies: fontFamilies, currentTextTheme: currentTextTheme, fontFamily: fontFamily);
                           },
                         );
                         await ref.read(fontFamilyNotifierProvider.notifier).setState(val);
@@ -406,6 +385,45 @@ class CustomSettingsScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+}
+
+class FontDialog extends StatelessWidget {
+  const FontDialog({
+    super.key,
+    required this.fontFamilies,
+    required this.currentTextTheme,
+    required this.fontFamily,
+  });
+
+  final List<MapEntry<String?, String>> fontFamilies;
+  final TextTheme currentTextTheme;
+  final String? fontFamily;
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioDialog<String?>(
+        itemCount: fontFamilies.length,
+        builder: (index) {
+          final fontFamily = fontFamilies[index];
+          return (
+            fontFamily.key,
+            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+              Text(fontFamily.value),
+              IconButton(
+                onPressed: () => showOkDialog(
+                  context: context,
+                  child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
+                      style: fontFamily.key != null
+                          ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme).headlineMedium
+                          : null),
+                ),
+                icon: const Icon(Icons.visibility),
+              ),
+            ])
+          );
+        },
+        initialValue: fontFamily);
   }
 }
 

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -60,7 +60,7 @@ class CustomSettingsScreen extends ConsumerWidget {
     }
 
     Future<(Locale?, ThemeMode, String?)> loadGeneralSettings() async {
-      var results = await Future.wait([
+      final results = await Future.wait([
         ref.watch(localeNotifierProvider),
         ref.watch(themeModeNotifierProvider),
         ref.watch(fontFamilyNotifierProvider)
@@ -76,9 +76,7 @@ class CustomSettingsScreen extends ConsumerWidget {
           LoadingBuilder<(Locale?, ThemeMode, String?)>(
               future: loadGeneralSettings(),
               builder: (context, generalSettings) {
-                var locale = generalSettings.$1;
-                var themeMode = generalSettings.$2;
-                var fontFamily = generalSettings.$3;
+                var (locale, themeMode, fontFamily) = generalSettings;
 
                 return SettingsSection(
                   title: localizations.general,
@@ -409,9 +407,9 @@ class FontDialogState extends State<FontDialog> {
     if (counter >= fontStock.length) return;
 
     setState(() => fontFamilies.add(fontStock[counter]));
-    await Future.delayed(const Duration(microseconds: 300));
+    await Future.delayed(const Duration(microseconds: 1000));
 
-    lazyLoadFonts(counter+1);
+    lazyLoadFonts(counter + 1);
   }
 
   @override

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -59,129 +59,129 @@ class CustomSettingsScreen extends ConsumerWidget {
       }
     }
 
+    Future<(Locale?, ThemeMode, String?)> loadGeneralSettings() async {
+      var results = await Future.wait([
+        ref.watch(localeNotifierProvider),
+        ref.watch(themeModeNotifierProvider),
+        ref.watch(fontFamilyNotifierProvider)
+      ]);
+
+      return (results[0] as Locale?, results[1] as ThemeMode, results[2] as String?);
+    }
+
     return WindowStateScaffold(
       appBarTitle: Text(localizations.settings),
       body: ResponsiveColumn(
         children: [
-          LoadingBuilder<Locale?>(
-            future: ref.watch(localeNotifierProvider),
-            builder: (context, locale) {
-              return LoadingBuilder<ThemeMode>(
-                future: ref.watch(themeModeNotifierProvider),
-                builder: (context, themeMode) {
-                  return LoadingBuilder<String?>(
-                      future: ref.watch(fontFamilyNotifierProvider),
-                      builder: (context, fontFamily) {
-                        return SettingsSection(
-                          title: localizations.general,
-                          action: TextButton(
-                            onPressed: () async {
-                              locale = null;
-                              await ref.read(localeNotifierProvider.notifier).setState(locale);
+          LoadingBuilder<(Locale?, ThemeMode, String?)>(
+              future: loadGeneralSettings(),
+              builder: (context, generalSettings) {
+                var locale = generalSettings.$1;
+                var themeMode = generalSettings.$2;
+                var fontFamily = generalSettings.$3;
 
-                              themeMode = ThemeMode.system;
-                              await ref.read(themeModeNotifierProvider.notifier).setState(themeMode);
+                return SettingsSection(
+                  title: localizations.general,
+                  action: TextButton(
+                    onPressed: () async {
+                      locale = null;
+                      await ref.read(localeNotifierProvider.notifier).setState(locale);
 
-                              const defaultFontFamily = 'Roboto';
-                              await ref.read(fontFamilyNotifierProvider.notifier).setState(defaultFontFamily);
-                            },
-                            child: Text(localizations.reset),
-                          ),
-                          children: [
-                            ListTile(
-                              leading: const Icon(Icons.translate),
-                              title: Text(localizations.language + (isDisplayInternational() ? ' | Language' : '')),
-                              subtitle: Text(getTranslationOfLocale(locale)),
-                              onTap: () async {
-                                final val = await showDialog<Locale?>(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    final List<MapEntry<Locale?, String>> languageSettingValues =
-                                        Preferences.supportedLanguages.map((locale) {
-                                      return MapEntry<Locale?, String>(locale, getTranslationOfLocale(locale));
-                                    }).toList();
-                                    languageSettingValues.insert(0, MapEntry(null, getTranslationOfLocale()));
-                                    return RadioDialog<Locale?>(values: languageSettingValues, initialValue: locale);
-                                  },
-                                );
-                                await ref.read(localeNotifierProvider.notifier).setState(val);
-                              },
-                            ),
-                            ListTile(
-                              leading: const Icon(Icons.brush),
-                              title: Text(localizations.themeMode),
-                              subtitle: Text(getTranslationOfThemeMode(themeMode)),
-                              onTap: () async {
-                                final val = await showDialog<ThemeMode>(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    final List<MapEntry<ThemeMode, String>> themeModeValues = ThemeMode.values
-                                        .map((value) =>
-                                            MapEntry<ThemeMode, String>(value, getTranslationOfThemeMode(value)))
-                                        .toList();
-                                    return RadioDialog<ThemeMode>(values: themeModeValues, initialValue: themeMode);
-                                  },
-                                );
-                                if (val != null) {
-                                  await ref.read(themeModeNotifierProvider.notifier).setState(val);
-                                }
-                              },
-                            ),
-                            ListTile(
-                              leading: const Icon(Icons.abc),
-                              trailing: IconButton(
-                                tooltip: 'Google Fonts',
-                                icon: const Icon(Icons.link),
-                                onPressed: () => launchUrl(Uri.parse('https://fonts.google.com/')),
-                              ),
-                              title: Text(localizations.fontFamily),
-                              subtitle: Text(fontFamily ?? localizations.systemSetting),
-                              onTap: () async {
-                                final currentTextTheme = Theme.of(context).textTheme;
-                                final val = await showDialog<String?>(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    final List<MapEntry<String?, String>> fontFamilies = GoogleFonts.asMap()
-                                        .keys
-                                        .map((String e) => MapEntry<String?, String>(e, e))
-                                        .toList();
-                                    fontFamilies.insert(
-                                        0, MapEntry<String?, String>(null, localizations.systemSetting));
-                                    return RadioDialog<String?>(
-                                        itemCount: fontFamilies.length,
-                                        builder: (index) {
-                                          final fontFamily = fontFamilies[index];
-                                          return (
-                                            fontFamily.key,
-                                            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-                                              Text(fontFamily.value),
-                                              IconButton(
-                                                onPressed: () => showOkDialog(
-                                                  context: context,
-                                                  child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
-                                                      style: fontFamily.key != null
-                                                          ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme)
-                                                              .headlineMedium
-                                                          : null),
-                                                ),
-                                                icon: const Icon(Icons.visibility),
-                                              ),
-                                            ])
-                                          );
-                                        },
-                                        initialValue: fontFamily);
-                                  },
-                                );
-                                await ref.read(fontFamilyNotifierProvider.notifier).setState(val);
-                              },
-                            ),
-                          ],
+                      themeMode = ThemeMode.system;
+                      await ref.read(themeModeNotifierProvider.notifier).setState(themeMode);
+
+                      const defaultFontFamily = 'Roboto';
+                      await ref.read(fontFamilyNotifierProvider.notifier).setState(defaultFontFamily);
+                    },
+                    child: Text(localizations.reset),
+                  ),
+                  children: [
+                    ListTile(
+                      leading: const Icon(Icons.translate),
+                      title: Text(localizations.language + (isDisplayInternational() ? ' | Language' : '')),
+                      subtitle: Text(getTranslationOfLocale(locale)),
+                      onTap: () async {
+                        final val = await showDialog<Locale?>(
+                          context: context,
+                          builder: (BuildContext context) {
+                            final List<MapEntry<Locale?, String>> languageSettingValues =
+                                Preferences.supportedLanguages.map((locale) {
+                              return MapEntry<Locale?, String>(locale, getTranslationOfLocale(locale));
+                            }).toList();
+                            languageSettingValues.insert(0, MapEntry(null, getTranslationOfLocale()));
+                            return RadioDialog<Locale?>(values: languageSettingValues, initialValue: locale);
+                          },
                         );
-                      });
-                },
-              );
-            },
-          ),
+                        await ref.read(localeNotifierProvider.notifier).setState(val);
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.brush),
+                      title: Text(localizations.themeMode),
+                      subtitle: Text(getTranslationOfThemeMode(themeMode)),
+                      onTap: () async {
+                        final val = await showDialog<ThemeMode>(
+                          context: context,
+                          builder: (BuildContext context) {
+                            final List<MapEntry<ThemeMode, String>> themeModeValues = ThemeMode.values
+                                .map((value) => MapEntry<ThemeMode, String>(value, getTranslationOfThemeMode(value)))
+                                .toList();
+                            return RadioDialog<ThemeMode>(values: themeModeValues, initialValue: themeMode);
+                          },
+                        );
+                        if (val != null) {
+                          await ref.read(themeModeNotifierProvider.notifier).setState(val);
+                        }
+                      },
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.abc),
+                      trailing: IconButton(
+                        tooltip: 'Google Fonts',
+                        icon: const Icon(Icons.link),
+                        onPressed: () => launchUrl(Uri.parse('https://fonts.google.com/')),
+                      ),
+                      title: Text(localizations.fontFamily),
+                      subtitle: Text(fontFamily ?? localizations.systemSetting),
+                      onTap: () async {
+                        final currentTextTheme = Theme.of(context).textTheme;
+                        final val = await showDialog<String?>(
+                          context: context,
+                          builder: (BuildContext context) {
+                            final List<MapEntry<String?, String>> fontFamilies =
+                                GoogleFonts.asMap().keys.map((String e) => MapEntry<String?, String>(e, e)).toList();
+                            fontFamilies.insert(0, MapEntry<String?, String>(null, localizations.systemSetting));
+                            return RadioDialog<String?>(
+                                itemCount: fontFamilies.length,
+                                builder: (index) {
+                                  final fontFamily = fontFamilies[index];
+                                  return (
+                                    fontFamily.key,
+                                    Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+                                      Text(fontFamily.value),
+                                      IconButton(
+                                        onPressed: () => showOkDialog(
+                                          context: context,
+                                          child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
+                                              style: fontFamily.key != null
+                                                  ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme)
+                                                      .headlineMedium
+                                                  : null),
+                                        ),
+                                        icon: const Icon(Icons.visibility),
+                                      ),
+                                    ])
+                                  );
+                                },
+                                initialValue: fontFamily);
+                          },
+                        );
+                        await ref.read(fontFamilyNotifierProvider.notifier).setState(val);
+                      },
+                    ),
+                  ],
+                );
+              }),
           LoadingBuilder<String>(
             future: ref.watch(bellSoundNotifierProvider),
             builder: (context, bellSoundPath) {

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -392,28 +392,31 @@ class _FontSelectionDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
-    final List<MapEntry<String?, String>> fontFamilies = [MapEntry<String?, String>(null, localizations.systemSetting)];
-    fontFamilies.addAll(GoogleFonts.asMap().keys.map((String e) => MapEntry<String?, String>(e, e)).toList());
+    final List<String?> fontFamilies = [null];
+    fontFamilies.addAll(GoogleFonts.asMap().keys.toList());
     return RadioDialog<String?>(
       shrinkWrap: false,
       itemCount: fontFamilies.length,
       builder: (index) {
         final fontFamily = fontFamilies[index];
+        final fontStyle = fontFamily != null
+            ? GoogleFonts.getTextTheme(fontFamily, currentTextTheme).headlineMedium
+            : Theme.of(context)
+                .textTheme
+                .apply(fontFamily: Typography.material2021().white.headlineMedium?.fontFamily)
+                .headlineMedium;
         return (
-          fontFamily.key,
+          fontFamily,
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(fontFamily.value),
+              Text(fontFamily ?? localizations.systemSetting, style: fontStyle),
               IconButton(
                 onPressed: () => showOkDialog(
                   context: context,
-                  child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
-                      style: fontFamily.key != null
-                          ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme).headlineMedium
-                          : null),
+                  child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz', style: fontStyle),
                 ),
-                icon: const Icon(Icons.visibility),
+                icon: const Icon(Icons.abc),
               ),
             ],
           ),

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -410,7 +410,7 @@ class _FontSelectionDialog extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(fontFamily ?? localizations.systemSetting, style: fontStyle),
+              Text(fontFamily ?? localizations.systemFont, style: fontStyle),
               IconButton(
                 onPressed: () => showOkDialog(
                   context: context,

--- a/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
+++ b/wrestling_scoreboard_client/lib/view/screens/more/settings/settings.dart
@@ -146,7 +146,7 @@ class CustomSettingsScreen extends ConsumerWidget {
                         final val = await showDialog<String?>(
                           context: context,
                           builder: (BuildContext context) {
-                            return FontDialog(currentTextTheme: currentTextTheme, fontFamily: fontFamily);
+                            return _FontSelectionDialog(currentTextTheme: currentTextTheme, fontFamily: fontFamily);
                           },
                         );
                         await ref.read(fontFamilyNotifierProvider.notifier).setState(val);
@@ -382,60 +382,44 @@ class CustomSettingsScreen extends ConsumerWidget {
   }
 }
 
-class FontDialog extends StatefulWidget {
+class _FontSelectionDialog extends StatelessWidget {
   final TextTheme currentTextTheme;
   final String? fontFamily;
 
-  const FontDialog({super.key, required this.currentTextTheme, required this.fontFamily});
-
-  @override
-  State<StatefulWidget> createState() => FontDialogState();
-}
-
-class FontDialogState extends State<FontDialog> {
-  final List<String> fontStock = [];
-  final List<String> fontFamilies = [];
-
-  @override
-  void initState() {
-    super.initState();
-    fontStock.addAll(GoogleFonts.asMap().keys);
-    lazyLoadFonts(0);
-  }
-
-  void lazyLoadFonts(int counter) async {
-    if (counter >= fontStock.length) return;
-
-    setState(() => fontFamilies.add(fontStock[counter]));
-    await Future.delayed(const Duration(microseconds: 1000));
-
-    lazyLoadFonts(counter + 1);
-  }
+  const _FontSelectionDialog({required this.currentTextTheme, required this.fontFamily});
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+
+    final List<MapEntry<String?, String>> fontFamilies = [MapEntry<String?, String>(null, localizations.systemSetting)];
+    fontFamilies.addAll(GoogleFonts.asMap().keys.map((String e) => MapEntry<String?, String>(e, e)).toList());
     return RadioDialog<String?>(
+      shrinkWrap: false,
       itemCount: fontFamilies.length,
       builder: (index) {
         final fontFamily = fontFamilies[index];
         return (
-          fontFamily,
-          Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-            Text(fontFamily),
-            IconButton(
-              onPressed: () => showOkDialog(
-                context: context,
-                child: Text(
-                  'ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
-                  style: GoogleFonts.getTextTheme(fontFamily, widget.currentTextTheme).headlineMedium,
+          fontFamily.key,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(fontFamily.value),
+              IconButton(
+                onPressed: () => showOkDialog(
+                  context: context,
+                  child: Text('ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz',
+                      style: fontFamily.key != null
+                          ? GoogleFonts.getTextTheme(fontFamily.key!, currentTextTheme).headlineMedium
+                          : null),
                 ),
+                icon: const Icon(Icons.visibility),
               ),
-              icon: const Icon(Icons.visibility),
-            ),
-          ])
+            ],
+          ),
         );
       },
-      initialValue: widget.fontFamily,
+      initialValue: fontFamily,
     );
   }
 }

--- a/wrestling_scoreboard_client/lib/view/widgets/dialogs.dart
+++ b/wrestling_scoreboard_client/lib/view/widgets/dialogs.dart
@@ -235,7 +235,7 @@ class _RadioDialogState<T> extends State<RadioDialog<T>> {
     return OkCancelDialog<T?>(
         isScrollable: widget.shrinkWrap,
         child: ListView.builder(
-          key: Key(result.toString()),
+          // key: Key(result.toString()), // Specifying a key will reset the list position, so try to avoid it.
           shrinkWrap: widget.shrinkWrap,
           itemCount: widget.itemCount ?? widget.values?.length,
           itemBuilder: (context, index) {

--- a/wrestling_scoreboard_client/lib/view/widgets/dialogs.dart
+++ b/wrestling_scoreboard_client/lib/view/widgets/dialogs.dart
@@ -7,17 +7,23 @@ import 'package:wrestling_scoreboard_client/view/widgets/exception.dart';
 
 class SizedDialog extends StatelessWidget {
   /// Do not wrap this into a column with shrinkwrap, so that ListViews act dynamically.
-  const SizedDialog({super.key, required this.actions, required this.child});
+  const SizedDialog({
+    super.key,
+    required this.actions,
+    required this.child,
+    this.isScrollable = true,
+  });
 
   final List<Widget> actions;
   final Widget child;
+  final bool isScrollable;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       content: SizedBox(
         width: 300,
-        child: SingleChildScrollView(child: child),
+        child: isScrollable ? SingleChildScrollView(child: child) : child,
       ),
       actions: actions,
     );
@@ -57,13 +63,21 @@ class OkCancelDialog<T extends Object?> extends StatelessWidget {
   final Widget child;
   final String? okText;
   final T Function() getResult;
+  final bool isScrollable;
 
-  const OkCancelDialog({required this.child, required this.getResult, this.okText, super.key});
+  const OkCancelDialog({
+    required this.child,
+    required this.getResult,
+    this.okText,
+    super.key,
+    this.isScrollable = true,
+  });
 
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
     return SizedDialog(
+      isScrollable: isScrollable,
       actions: <Widget>[
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -191,6 +205,7 @@ class RadioDialog<T> extends StatefulWidget {
   final T? initialValue;
   final int? itemCount;
   final void Function(T? value)? onChanged;
+  final bool shrinkWrap;
 
   const RadioDialog({
     super.key,
@@ -199,6 +214,7 @@ class RadioDialog<T> extends StatefulWidget {
     required this.initialValue,
     this.onChanged,
     this.itemCount,
+    this.shrinkWrap = true,
   }) : assert(values != null || builder != null);
 
   @override
@@ -217,9 +233,10 @@ class _RadioDialogState<T> extends State<RadioDialog<T>> {
   @override
   Widget build(BuildContext context) {
     return OkCancelDialog<T?>(
+        isScrollable: widget.shrinkWrap,
         child: ListView.builder(
           key: Key(result.toString()),
-          shrinkWrap: true,
+          shrinkWrap: widget.shrinkWrap,
           itemCount: widget.itemCount ?? widget.values?.length,
           itemBuilder: (context, index) {
             final T? key;


### PR DESCRIPTION
Could be split up into dedicated pull request if necessary, but I'd prefer to rebase this branch if changes occur.

4c7ed02

Parallelizes LoadingBuilders in Settings for the first block. Could/should also be done further down, but this is a first proof of concept.

65871dc

Extracts the FontRadioDialog Widget

bedd444

Modifies the FontDialog to have a state and lazy loads the fonts. It loads one font each 300 ms currently which is a fine speed, but there's way too many fonts available to ever reach reasonable performance. Either there needs to be a subset for selection or buffering needs to start upon launching the app (which is not reasonable imo).